### PR TITLE
Update AdGuard Home DNS Lists and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,30 @@
-# Adguard Home
-## My personal adguard-home lists
-### dns-allowlist.txt - Whitelist for DNS
-### dns-blocklist.txt - Blacklist for DNS
+# jmcglock AdGuard Home Lists
+
+## Personal AdGuard Home Lists
+
+This repository contains custom DNS blocklists and allowlists for use with AdGuard Home. These lists help in blocking unwanted ads, trackers, and other undesirable content while allowing necessary services to function correctly.
+
+### dns-allowlist.txt - DNS Allowlist
+
+The `dns-allowlist.txt` file contains domains that are explicitly allowed. This is useful for ensuring that essential services and websites are not blocked by the DNS blocklist. To use this allowlist, add the following URL to your AdGuard Home allowlist settings:
+
+```
+https://raw.githubusercontent.com/jmcglock/adguard-home/main/dns-allowlist.txt
+```
+
+### dns-blocklist.txt - DNS Blocklist
+
+The `dns-blocklist.txt` file contains domains that are blocked to prevent ads, trackers, and other unwanted content. To use this blocklist, add the following URL to your AdGuard Home blocklist settings:
+
+```
+https://raw.githubusercontent.com/jmcglock/adguard-home/main/dns-blocklist.txt
+```
+
+### How to Use
+
+1. Open your AdGuard Home dashboard.
+2. Navigate to the "Filters" section.
+3. Add the URLs provided above to the respective allowlist and blocklist sections.
+4. Apply the changes and update the lists.
+
+By using these lists, you can enhance your browsing experience by blocking unwanted content while ensuring that necessary services remain accessible.

--- a/dns-adlists.md
+++ b/dns-adlists.md
@@ -1,0 +1,11 @@
+# My AdGuard Home DNS Lists
+
+## Blocklists
+- [HaGeZi's Ultimate Blocklist](https://adguardteam.github.io/HostlistsRegistry/assets/filter_49.txt)
+- [HaGeZi's Threat Intelligence Feeds](https://adguardteam.github.io/HostlistsRegistry/assets/filter_44.txt) 
+- [jmcglock's DNS Blocklist](https://raw.githubusercontent.com/jmcglock/adguard-home/main/dns-blocklist.txt)
+
+## Allowlists
+- [jmcglock's DNS Allowlist](https://raw.githubusercontent.com/jmcglock/adguard-home/main/dns-allowlist.txt)
+
+> These curated lists are used with AdGuard Home for DNS filtering

--- a/dns-adlists.txt
+++ b/dns-adlists.txt
@@ -1,8 +1,0 @@
-# I only use these lists on my adguard-home server
-https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/ultimate.txt
-https://raw.githubusercontent.com/hagezi/dns-blocklists/main/adblock/tif.txt
-https://raw.githubusercontent.com/jmcglock/adguard-home/main/dns-blocklist.txt
-https://big.oisd.nl/
-https://nsfw.oisd.nl/
-# allowlist
-https://raw.githubusercontent.com/jmcglock/adguard-home/main/dns-allowlist.txt

--- a/dns-allowlist.txt
+++ b/dns-allowlist.txt
@@ -1,49 +1,73 @@
-#    _                     _            _    
-#   (_)                   | |          | |   
-#    _ _ __ ___   ___ __ _| | ___   ___| | __
-#   | | '_ ` _ \ / __/ _` | |/ _ \ / __| |/ /
-#   | | | | | | | (_| (_| | | (_) | (__|   < 
-#   | |_| |_| |_|\___\__, |_|\___/ \___|_|\_\
-#  _/ |               __/ |                  
-# |__/               |___/                   
-# I always allow these URLS. @@||
-@@||cloudflare.com^
-@@||demdex.net^
-@@||discordapp.com^
-@@||espncdn.com^
-@@||dcf.espn.com^
-@@||gamepass.com^
+#      ██╗███╗   ███╗ ██████╗ ██████╗ ██╗      ██████╗  ██████╗██╗  ██╗
+#      ██║████╗ ████║██╔════╝██╔════╝ ██║     ██╔═══██╗██╔════╝██║ ██╔╝
+#      ██║██╔████╔██║██║     ██║  ███╗██║     ██║   ██║██║     █████╔╝ 
+# ██   ██║██║╚██╔╝██║██║     ██║   ██║██║     ██║   ██║██║     ██╔═██╗ 
+# ╚█████╔╝██║ ╚═╝ ██║╚██████╗╚██████╔╝███████╗╚██████╔╝╚██████╗██║  ██╗
+# ╚════╝ ╚═╝     ╚═╝ ╚═════╝ ╚═════╝ ╚══════╝ ╚═════╝  ╚═════╝╚═╝  ╚═╝
+# DNS Allowlist for Adguard Home
+
+# Apple Services
+@@||apple.com^
+@@||amp-api-edge.apps.apple.com^
+@@||amp-api-search-edge.apps.apple.com^
+@@||smoot.apple.com^
+
+# Microsoft Services
+@@||microsoft.com^
+@@||visualstudio.com^
+@@||windows.com^
+@@||windowsupdate.com^
+@@||xboxlive.com^
+
+# Development & Code Hosting
 @@||ghcr.io^
 @@||github.com^
 @@||github.io^
 @@||gitlab.com^
 @@||googleapis.com^
-@@||fonts.gstatic.com^
-@@||ads-fa-darwin.hulustream.com^
+
+# Social & Media
+@@||discordapp.com^
 @@||graph.facebook.com^
 @@||graph.instagram.com^
 @@||i.instagram.com^
-@@||intuit.com^
+@@||pinimg.com^
+@@||soundcloud.com^
+@@||spotify.com^
+@@||scdn.co^
+@@||s.youtube.com^
+
+# Streaming Services
+@@||ads-fa-darwin.hulustream.com^
+@@||hulu.hb-api.omtrdc.net^
 @@||megaphone.fm^
-@@||microsoft.com^
 @@||nbcsports.com^
+@@||peacocktv.com^
+
+# Sports
+@@||dcf.espn.com^
+@@||espncdn.com^
+@@||gamepass.com^
+
+# Utilities & Services
+@@||demdex.net^
+@@||fonts.gstatic.com^
+@@||intuit.com^
 @@||nerdfonts.com^
 @@||nextdns.io^
 @@||omtrdc.net^
-@@||hulu.hb-api.omtrdc.net^
-@@||peacocktv.com^
-@@||pinimg.com^
 @@||rancher.io^
-@@||scdn.co^
 @@||simplelogin.io^
-@@||soundcloud.com^
-@@||spotify.com^
-@@||typekit.net
+@@||typekit.net^
 @@||ubuntu.com^
 @@||ui.com^
 @@||urbanairship.com^
-@@||visualstudio.com^
-@@||windows.com^
-@@||windowsupdate.com^
-@@||xboxlive.com^
-@@||s.youtube.com^
+
+# Tesla
+@@||tesla.com^
+@@||tesla.services^
+@@||tessie.com^
+
+# Additional Common Services
+@@||akamai.net^
+@@||cloudflare.com^

--- a/dns-blocklist.txt
+++ b/dns-blocklist.txt
@@ -1,149 +1,101 @@
-#    _                     _            _    
-#   (_)                   | |          | |   
-#    _ _ __ ___   ___ __ _| | ___   ___| | __
-#   | | '_ ` _ \ / __/ _` | |/ _ \ / __| |/ /
-#   | | | | | | | (_| (_| | | (_) | (__|   < 
-#   | |_| |_| |_|\___\__, |_|\___/ \___|_|\_\
-#  _/ |               __/ |                  
-# |__/               |___/                   
-# I always block these URLS.
-||advice-ads.s3.amazonaws.com^
-||analytics.s3.amazonaws.com^
-||events.hotjar.io^
-||adtago.s3.amazonaws.com^
-||advertising-api-eu.amazon.com^
-||freshmarketer.com^
-||click.googleanalytics.com^
-||claritybt.freshmarketer.com^
-||fwtracks.freshmarketer.com^
-||analyticsengine.s3.amazonaws.com^
-||stats.wp.com^
-||notify.bugsnag.com^
-||sessions.bugsnag.com^
-||app-measurement.com^
-||api.bugsnag.com^
-||app.bugsnag.com^
-||browser.sentry-cdn.com^
-||app.getsentry.com^
-||ads.pinterest.com^
-||log.pinterest.com^
-||analytics.pinterest.com^
-||trk.pinterest.com^
-||widgets.pinterest.com^
-||events.redditmedia.com^
-||ads.youtube.com^
-||log.byteoversea.com^
-||geo.yahoo.com^
-||udc.yahoo.com^
-||udcm.yahoo.com^
-||analytics.query.yahoo.com^
-||partnerads.ysm.yahoo.com^
-||log.fc.yahoo.com^
-||gemini.yahoo.com^
+#      ██╗███╗   ███╗ ██████╗ ██████╗ ██╗      ██████╗  ██████╗██╗  ██╗
+#      ██║████╗ ████║██╔════╝██╔════╝ ██║     ██╔═══██╗██╔════╝██║ ██╔╝
+#      ██║██╔████╔██║██║     ██║  ███╗██║     ██║   ██║██║     █████╔╝ 
+# ██   ██║██║╚██╔╝██║██║     ██║   ██║██║     ██║   ██║██║     ██╔═██╗ 
+# ╚█████╔╝██║ ╚═╝ ██║╚██████╗╚██████╔╝███████╗╚██████╔╝╚██████╗██║  ██╗
+# ╚════╝ ╚═╝     ╚═╝ ╚═════╝ ╚═════╝ ╚══════╝ ╚═════╝  ╚═════╝╚═╝  ╚═╝
+# DNS Blocklist for Adguard Home
+
+# Analytics & Tracking
+||google-analytics.com^
+||ssl.google-analytics.com^
 ||analytics.google.com^
-||adtech.yahooinc.com^
-||metrika.yandex.ru^
-||advertising.yandex.ru^
-||offerwall.yandex.net^
-||auction.unityads.unity3d.com^
-||extmaps-api.yandex.net^
-||appmetrica.yandex.ru^
-||adfstat.yandex.ru^
-||webview.unityads.unity3d.com^
-||config.unityads.unity3d.com^
-||adserver.unityads.unity3d.com^
-||iot-eu-logser.realme.com^
-||iot-logser.realme.com^
-||bdapi-ads.realmemobile.com^
-||bdapi-in-ads.realmemobile.com^
-||api.ad.xiaomi.com^
-||tracking.rus.miui.com^
-||metrics.data.hicloud.com^
-||nmetrics.samsung.com^
-||click.oneplus.cn^
-||api-adservices.apple.com^
-||sdkconfig.ad.xiaomi.com^
-||smetrics.samsung.com^
-||adx.ads.oppomobile.com^
-||logbak.hicloud.com^
-||notes-analytics-events.apple.com^
-||metrics2.data.hicloud.com^
-||iadsdk.apple.com^
-||data.mistat.india.xiaomi.com^
-||data.mistat.xiaomi.com^
-||metrics.icloud.com^
-||adsfs.oppomobile.com^
-||tr.iadsdk.apple.com^
-||logservice1.hicloud.com^
-||books-analytics-events.apple.com^
-||analytics-api.samsunghealthcn.com^
-||open.oneplus.net^
-||sdkconfig.ad.intl.xiaomi.com^
-||globalapi.ad.xiaomi.com^
-||advertising.apple.com^
-||ck.ads.oppomobile.com^
-||weather-analytics-events.apple.com^
-||logservice.hicloud.com^
-||data.mistat.rus.xiaomi.com^
-||metrics.mzstatic.com^
-||samsungads.com^
-||data.ads.oppomobile.com^
-||grs.hicloud.com^
-||metrics.apple.com^
+||click.googleanalytics.com^
+||app-measurement.com^
+||analytics.s3.amazonaws.com^
+||analyticsengine.s3.amazonaws.com^
+
+# Ad Services
 ||pagead2.googlesyndication.com^
 ||adservice.google.com^
 ||afs.googlesyndication.com^
 ||pagead2.googleadservices.com^
-||m.doubleclick.net^
-||stats.g.doubleclick.net^
-||ads30.adcolony.com^
-||adc3-launch.adcolony.com^
-||mediavisor.doubleclick.net^
-||static.media.net^
-||events3alt.adcolony.com^
-||ssl.google-analytics.com^
-||google-analytics.com^
-||media.net^
+||doubleclick.net^
+||ad.doubleclick.net^
 ||static.doubleclick.net^
+||stats.g.doubleclick.net^
+||mediavisor.doubleclick.net^
+
+# Social Media Tracking
+||pixel.facebook.com^
+||an.facebook.com^
+||analytics.tiktok.com^
+||analytics-sg.tiktok.com^
+||ads-api.tiktok.com^
+||ads-sg.tiktok.com^
+||ads.tiktok.com^
+||business-api.tiktok.com^
+||ads.linkedin.com^
+||analytics.pointdrive.linkedin.com^
+||static.ads-twitter.com^
+||ads-api.twitter.com^
+
+# Mobile Device Analytics
+||metrics.apple.com^
+||api-adservices.apple.com^
+||iadsdk.apple.com^
+||tr.iadsdk.apple.com^
+||advertising.apple.com^
+||metrics.icloud.com^
+||notes-analytics-events.apple.com^
+||books-analytics-events.apple.com^
+||weather-analytics-events.apple.com^
+
+# Third Party Analytics
+||mouseflow.com^
+||api.mouseflow.com^
+||cdn.mouseflow.com^
+||tools.mouseflow.com^
+||gtm.mouseflow.com^
+||hotjar.com^
+||events.hotjar.io^
 ||script.hotjar.com^
 ||identify.hotjar.com^
 ||insights.hotjar.com^
-||wd.adcolony.com^
-||adm.hotjar.com^
-||ad.doubleclick.net^
-||cdn.mouseflow.com^
 ||surveys.hotjar.com^
-||api.mouseflow.com^
-||careers.hotjar.com^
-||o2.mouseflow.com^
-||mouseflow.com^
-||luckyorange.com^
-||adservetx.media.net^
-||realtime.luckyorange.com^
-||tools.mouseflow.com^
-||cdn.luckyorange.com^
-||cs.luckyorange.net^
-||settings.luckyorange.net^
-||cdn-test.mouseflow.com^
-||gtm.mouseflow.com^
-||pixel.facebook.com^
-||static.ads-twitter.com^
-||api.luckyorange.com^
-||an.facebook.com^
-||ads.linkedin.com^
-||ads-api.twitter.com^
-||upload.luckyorange.net^
-||analytics.tiktok.com^
-||w1.luckyorange.com^
-||events.reddit.com^
-||analytics.pointdrive.linkedin.com^
-||analytics-sg.tiktok.com^
-||analytics.yahoo.com^
-||advertising.yahoo.com^
-||adfox.yandex.ru^
-||ads-api.tiktok.com^
-||ads-sg.tiktok.com^
-||business-api.tiktok.com^
-||ads.tiktok.com^
-||ads.yahoo.com^
+||adm.hotjar.com^
+
+# Error Tracking
+||notify.bugsnag.com^
+||sessions.bugsnag.com^
+||api.bugsnag.com^
+||app.bugsnag.com^
+||browser.sentry-cdn.com^
+||app.getsentry.com^
+
+# Amazon Related
+||advice-ads.s3.amazonaws.com^
+||adtago.s3.amazonaws.com^
+||advertising-api-eu.amazon.com^
+
+# Spammy Tech Companies
+||api.ad.xiaomi.com^
+||sdkconfig.ad.xiaomi.com^
+||data.mistat.xiaomi.com^
+||data.mistat.india.xiaomi.com^
+||data.mistat.rus.xiaomi.com^
+||globalapi.ad.xiaomi.com^
+||nmetrics.samsung.com^
+||smetrics.samsung.com^
+||samsungads.com^
 ||samsung-com.112.2o7.net^
+
+# Additional Ad Networks
+||media.net^
+||static.media.net^
+||adservetx.media.net^
+||adcolony.com^
+||ads30.adcolony.com^
+||adc3-launch.adcolony.com^
+||events3alt.adcolony.com^
+||wd.adcolony.com^


### PR DESCRIPTION
Revise the AdGuard Home DNS lists to enhance clarity and usability. Update documentation to provide detailed instructions on using the allowlist and blocklist, while removing outdated entries.