### PR TITLE
2026 Update

### DIFF
--- a/dns-allowlist.txt
+++ b/dns-allowlist.txt
@@ -6,7 +6,6 @@
 # ╚════╝ ╚═╝     ╚═╝ ╚═════╝ ╚═════╝ ╚══════╝ ╚═════╝  ╚═════╝╚═╝  ╚═╝
 # DNS Allowlist for Adguard Home
 @@||akamai.net^
-@@||ads-fa-darwin.hulustream.com^
 @@||amp-api-edge.apps.apple.com^
 @@||amp-api-search-edge.apps.apple.com^
 @@||apple.com^
@@ -17,7 +16,6 @@
 @@||cloudflare.com^
 @@||cybertron.id.peacocktv.com^
 @@||dcf.espn.com^
-@@||demdex.net^
 @@||discordapp.com^
 @@||espn.com^
 @@||espncdn.com^
@@ -31,7 +29,6 @@
 @@||googleapis.com^
 @@||graph.facebook.com^
 @@||graph.instagram.com^
-@@||hulu.hb-api.omtrdc.net^
 @@||i.instagram.com^
 @@||imageservice.disco.peacocktv.com^
 @@||intuit.com^
@@ -42,7 +39,6 @@
 @@||nbcsports.com^
 @@||nerdfonts.com^
 @@||nextdns.io^
-@@||omtrdc.net^
 @@||ovp.peacocktv.com^
 @@||pconfig-prd.cdn.peacocktv.com^
 @@||peacocktv.com^
@@ -61,7 +57,6 @@
 @@||typekit.net^
 @@||ubuntu.com^
 @@||ui.com^
-@@||urbanairship.com^
 @@||visualstudio.com^
 @@||windows.com^
 @@||windowsupdate.com^

--- a/dns-blocklist.txt
+++ b/dns-blocklist.txt
@@ -47,6 +47,7 @@
 ||data.mistat.xiaomi.com^
 ||doubleclick.net^
 ||events.hotjar.io^
+||events.reddit.com^
 ||events3alt.adcolony.com^
 ||g008-vod-us-cmaf-prd-cc.cdn.peacocktv.com^
 ||g008-vod-us-cmaf-prd-fy.cdn.peacocktv.com^
@@ -70,6 +71,7 @@
 ||pagead2.googleadservices.com^
 ||pagead2.googlesyndication.com^
 ||pixel.facebook.com^
+||pixel.linkedin.com^
 ||samsung-com.112.2o7.net^
 ||samsungads.com^
 ||script.hotjar.com^
@@ -83,8 +85,11 @@
 ||stats.g.doubleclick.net^
 ||surveys.hotjar.com^
 ||tools.mouseflow.com^
+||telemetry.microsoft.com^
 ||tr.iadsdk.apple.com^
+||tr.snapchat.com^
 ||userdata.sr.roku.com^
+||vortex.data.microsoft.com^
 ||video-ads-module.ad-tech.nbcuni.com^
 ||wd.adcolony.com^
 ||weather-analytics-events.apple.com^


### PR DESCRIPTION
## Allowlist — removed (5)
- `@@||ads-fa-darwin.hulustream.com^` — Hulu ad server
- `@@||demdex.net^` — Adobe Audience Manager tracking
- `@@||omtrdc.net^` — Adobe Omniture analytics
- `@@||hulu.hb-api.omtrdc.net^` — Adobe tracking for Hulu
- `@@||urbanairship.com^` — Push notification platform

## Blocklist — added (5)
- `||events.reddit.com^` — Reddit analytics
- `||pixel.linkedin.com^` — LinkedIn tracking pixel
- `||telemetry.microsoft.com^` — Windows telemetry
- `||tr.snapchat.com^` — Snapchat tracking
- `||vortex.data.microsoft.com^` — Windows telemetry